### PR TITLE
Avoid logging CloudWatch message contents

### DIFF
--- a/logging/cloudwatch_logger.py
+++ b/logging/cloudwatch_logger.py
@@ -50,7 +50,7 @@ def handle_client(conn, addr, cloudwatch, log_group, log_stream):
             if not data:
                 break
             message = data.decode()
-            logger.debug(f"Received log: {message}")
+            logger.debug("Forwarding log to CloudWatch")
             try:
                 cloudwatch.put_log_events(
                     logGroupName=log_group,


### PR DESCRIPTION
Fixes #2

- Stop logging message contents locally (only forwards them to CloudWatch); per-message log is now just a DEBUG "Forwarding log to CloudWatch" line.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/nitro-toolkit/pull/6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging configuration to optimize verbosity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
