### PR TITLE
feat: add ping/pong to credential requester

### DIFF
--- a/credential_requester/credential_requester.py
+++ b/credential_requester/credential_requester.py
@@ -4,6 +4,7 @@ import json
 import logging
 import threading
 import argparse
+import time
 import boto3
 from botocore.exceptions import ClientError
 
@@ -117,6 +118,9 @@ def handle_client(conn, addr):
                 "Region": region
             }
             response = ParentResponse("credentials", response_value)
+            conn.send(json.dumps(response.__dict__).encode())
+        elif request.request_type == "ping":
+            response = ParentResponse("pong", {"unix_ms": int(time.time() * 1000)})
             conn.send(json.dumps(response.__dict__).encode())
         elif request.request_type == "SecretsManager":
             if not request.key_name:


### PR DESCRIPTION
Adds a lightweight ping/pong request_type over VSOCK (port 8003) to support periodic enclave→parent health checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/nitro-toolkit/pull/7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ping request handling that responds with pong messages containing current timestamp information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->