### PR TITLE
Revert credential-requester ping/pong

### DIFF
--- a/credential_requester/credential_requester.py
+++ b/credential_requester/credential_requester.py
@@ -4,7 +4,6 @@ import json
 import logging
 import threading
 import argparse
-import time
 import boto3
 from botocore.exceptions import ClientError
 
@@ -118,9 +117,6 @@ def handle_client(conn, addr):
                 "Region": region
             }
             response = ParentResponse("credentials", response_value)
-            conn.send(json.dumps(response.__dict__).encode())
-        elif request.request_type == "ping":
-            response = ParentResponse("pong", {"unix_ms": int(time.time() * 1000)})
             conn.send(json.dumps(response.__dict__).encode())
         elif request.request_type == "SecretsManager":
             if not request.key_name:


### PR DESCRIPTION
Removes the ping/pong request type from credential_requester.py.\n\nWe’re reverting the ping-based healthcheck approach in opensecret because it can be healthy while external egress (traffic_forwarder/proxy path) is broken, creating false positives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/nitro-toolkit/pull/11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed ping request handling and related unused dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->